### PR TITLE
変なカレンダー生成プログラムの作成（レベル3）

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+	"name": "Ruby",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "ruby:3.3.5-bullseye"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "ruby --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/lib/sg_strange_calendar.rb
+++ b/lib/sg_strange_calendar.rb
@@ -1,9 +1,36 @@
+require 'date'
+
 class SgStrangeCalendar
+  WDAYS = %w[Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo].freeze
+  MONTHS = %w[Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec].freeze
+  BLANK = ' '.freeze
+
   def initialize(year, today = nil)
-    # write your code here
+    @year = year
+    @today = today
   end
 
   def generate(vertical: false)
-    # write your code here
+    header = (vertical ? MONTHS : WDAYS).dup.unshift("#{@year}")
+    ths = (vertical ? WDAYS : MONTHS).dup
+    length = vertical ? 3 : 2
+    calendar = days(length:).then { vertical ? _1.transpose : _1 }.map do |line|
+      line.unshift(ths.shift.ljust(4))
+      line.join(' ').then { _1.gsub(/\s(\[\d{,2}\])(?:\s|\z)/) { "#{$1}" } }.rstrip
+    end
+    calendar.unshift(header.join(' ')).join("\n")
+  end
+
+  private
+
+  def days(length:)
+    [*1..12].map do |month|
+      begining_of_month, end_of_month = Date.new(@year, month, 1), Date.new(@year, month, -1)
+      array = [*begining_of_month..end_of_month].map do |date|
+        date == @today ? "[#{date.day}]".rjust(length + 2) : date.day.to_s.rjust(length)
+      end
+      begining_of_month.wday.times { array.unshift(BLANK.rjust(length)) }
+      array.fill(BLANK.rjust(length), array.size..WDAYS.size - 1)
+    end
   end
 end

--- a/lib/sg_strange_calendar.rb
+++ b/lib/sg_strange_calendar.rb
@@ -1,36 +1,70 @@
 require 'date'
 
 class SgStrangeCalendar
-  WDAYS = %w[Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo].freeze
-  MONTHS = %w[Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec].freeze
-  BLANK = ' '.freeze
-
   def initialize(year, today = nil)
     @year = year
     @today = today
   end
 
   def generate(vertical: false)
-    header = (vertical ? MONTHS : WDAYS).dup.unshift("#{@year}")
-    ths = (vertical ? WDAYS : MONTHS).dup
-    length = vertical ? 3 : 2
-    calendar = days(length:).then { vertical ? _1.transpose : _1 }.map do |line|
-      line.unshift(ths.shift.ljust(4))
-      line.join(' ').then { _1.gsub(/\s(\[\d{,2}\])(?:\s|\z)/) { "#{$1}" } }.rstrip
-    end
-    calendar.unshift(header.join(' ')).join("\n")
+    builder = vertical ? VerticalBuilder : HorizontalBuilder
+    builder.new(@year, @today).build
   end
 
-  private
+  class Builder
+    WDAYS = %w[Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo].freeze
+    MONTHS = %w[Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec].freeze
+    BLANK = ' '.freeze
 
-  def days(length:)
-    [*1..12].map do |month|
+    private_constant :WDAYS, :MONTHS, :BLANK
+
+    def initialize(year, today)
+      @year = year
+      @today = today
+    end
+
+    def build
+      calendar = rows.map.with_index do |line, i|
+        [ths[i].ljust(4), *line].join(' ').gsub(/\s(\[\d+\])(?:\s|\z)/) { $1 }.rstrip
+      end
+      [header.join(' '), *calendar].join("\n")
+    end
+
+    private
+
+    def days_in(month)
       begining_of_month, end_of_month = Date.new(@year, month, 1), Date.new(@year, month, -1)
       array = [*begining_of_month..end_of_month].map do |date|
         date == @today ? "[#{date.day}]".rjust(length + 2) : date.day.to_s.rjust(length)
       end
-      begining_of_month.wday.times { array.unshift(BLANK.rjust(length)) }
-      array.fill(BLANK.rjust(length), array.size..WDAYS.size - 1)
+      forward_blanks = Array.new(begining_of_month.wday, BLANK.rjust(length))
+      array.unshift(*forward_blanks)
+      array.fill(BLANK.rjust(length), array.size...WDAYS.size)
     end
+
+    def header = raise NotImplementedError
+    def ths = raise NotImplementedError
+    def length = raise NotImplementedError
+    def rows = raise NotImplementedError
   end
+
+  class HorizontalBuilder < Builder
+    private
+
+    def header = @header ||= [@year.to_s, *WDAYS.dup]
+    def ths = @ths ||= MONTHS.dup
+    def length = 2
+    def rows = @rows ||= [*1..12].map(&method(:days_in))
+  end
+
+  class VerticalBuilder < Builder
+    private
+
+    def header = @header ||= [@year.to_s, *MONTHS.dup]
+    def ths = @ths ||= WDAYS.dup
+    def length = 3
+    def rows = @rows ||= [*1..12].map(&method(:days_in)).transpose
+  end
+
+  private_constant :Builder, :HorizontalBuilder, :VerticalBuilder
 end

--- a/test/sg_strange_calendar_test.rb
+++ b/test/sg_strange_calendar_test.rb
@@ -107,7 +107,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_2_all
-    skip "レベル2にチャレンジする人はこの行を削除してください"
     file_path = File.expand_path('level2.txt', File.dirname(__FILE__))
     calendars = File.read(file_path).lines.each_slice(13).map(&:join).map(&:chomp)
     from_date = Date.new(2025, 1, 1)
@@ -303,7 +302,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_3_all
-    skip "レベル2およびレベル3にチャレンジする人はこの行を削除してください"
     file_path = File.expand_path('level3.txt', File.dirname(__FILE__))
     calendars = File.read(file_path).lines.each_slice(38).map(&:join).map(&:chomp)
     from_date = Date.new(2025, 1, 1)

--- a/test/sg_strange_calendar_test.rb
+++ b/test/sg_strange_calendar_test.rb
@@ -44,7 +44,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_2_for_2024_01_01
-    skip "レベル2にチャレンジする人はこの行を削除してください"
     expected = <<~TXT.chomp
       2024 Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo
       Jan     [1] 2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
@@ -66,7 +65,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_2_for_2024_12_09
-    skip "レベル2にチャレンジする人はこの行を削除してください"
     expected = <<~TXT.chomp
       2024 Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo
       Jan      1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
@@ -88,7 +86,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_2_for_2025_03_31
-    skip "レベル2にチャレンジする人はこの行を削除してください"
     expected = <<~TXT.chomp
       2025 Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo
       Jan            1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
@@ -123,7 +120,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_3_for_2024
-    skip "レベル2およびレベル3にチャレンジする人はこの行を削除してください"
     expected = <<~TXT.chomp
       2024 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
       Su                                     1           1
@@ -169,7 +165,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_3_for_2024_01_01
-    skip "レベル2およびレベル3にチャレンジする人はこの行を削除してください"
     expected = <<~TXT.chomp
       2024 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
       Su                                     1           1
@@ -216,7 +211,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_3_for_2024_12_09
-    skip "レベル2およびレベル3にチャレンジする人はこの行を削除してください"
     expected = <<~TXT.chomp
       2024 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
       Su                                     1           1
@@ -263,7 +257,6 @@ class SgStrangeCalendarTest < Minitest::Test
   end
 
   def test_level_3_for_2025_03_31
-    skip "レベル2およびレベル3にチャレンジする人はこの行を削除してください"
     expected = <<~TXT.chomp
       2025 Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec
       Su                         1


### PR DESCRIPTION
## 自分が解いたレベル（レベル1〜3）
3

## 頑張ったところ
縦横の切り替えを`Array#transpose`で概ね実現することで、切り替えに必要なコード量を少なくしました。

## 苦労したところ
日付が強調される場合、前後の日付との間の空白がなくなるという、配列の特定の数字を"[]"で囲ってjoinすれば良いという安直な実装を許さない仕様になっていたところに苦労しました。"[]"で囲った数値はrjustの引数を+2しておき、join後に正規表現で前後の空白を取り除くことで対応しました。

## 工夫したところ
横向きのカレンダーと縦向きのカレンダーの生成をFactoryMethodパターンで別々のクラスに分離して実装しています。

## コードを書くのにかかった時間
1h + 30min(refactor)

## だいたいのプログラミング歴
5年くらい

## 実際に解いてみた感想
Rubyにはお役立ちメソッドがたくさんあって便利だなぁ。

## 伊藤さんにメッセージ
今の自分の伸び代を認識したく応募しました。
コードレビューよろしくお願いいたします。